### PR TITLE
Grid span fix.

### DIFF
--- a/Cerulean.Common/Base/Component.cs
+++ b/Cerulean.Common/Base/Component.cs
@@ -117,7 +117,7 @@ namespace Cerulean.Common
 
             if (!CanBeParent) return;
             foreach (var child in Children)
-                child.Update(window, clientArea);
+                child.Update(window, new Size(clientArea.W - child.X, clientArea.H - child.Y));
         }
 
         public virtual void Draw(IGraphics graphics, int viewportX, int viewportY, Size viewportSize)

--- a/Cerulean.Components/Containers/Grid.cs
+++ b/Cerulean.Components/Containers/Grid.cs
@@ -144,7 +144,7 @@ namespace Cerulean.Components
                      (i < child.GridRowSpan || child.GridRowSpan == 0) && child.GridRow + i < RowCount;
                      i++)
                 {
-                    height += _cellSizes[child.GridRow + i, child.GridColumn].H;
+                    height += Math.Max(0, _cellSizes[child.GridRow + i, child.GridColumn].H);
                 }
                 // if i < span OR i 0
                 // AND i < column count
@@ -152,7 +152,7 @@ namespace Cerulean.Components
                      (i < child.GridColumnSpan || child.GridColumnSpan == 0) && child.GridColumn + i < ColumnCount;
                      i++)
                 {
-                    width += _cellSizes[child.GridRow, child.GridColumn + i].W;
+                    width += Math.Max(0, _cellSizes[child.GridRow, child.GridColumn + i].W);
                 }
                 child.Update(window, new Size(width, height));
             }
@@ -234,11 +234,11 @@ namespace Cerulean.Components
                 for (var columnIndex = component.GridColumn;
                      columnIndex < component.GridColumn + component.GridColumnSpan && component.GridColumn < ColumnCount;
                      ++columnIndex)
-                    childViewport.W += _cellSizes![0, columnIndex].W;
+                    childViewport.W += Math.Max(0, _cellSizes![0, columnIndex].W);
                 for (var rowIndex = component.GridRow;
                      rowIndex < component.GridRow + component.GridRowSpan && component.GridRow < RowCount;
                      ++rowIndex)
-                    childViewport.H += _cellSizes![rowIndex, 0].H;
+                    childViewport.H += Math.Max(0, _cellSizes![rowIndex, 0].H);
 
                 var aX = childViewportX + Math.Max(0, component.X);
                 var aY = childViewportY + Math.Max(0, component.Y);
@@ -254,9 +254,9 @@ namespace Cerulean.Components
                     offsetX = oldX + component.X;
                 }
                 // check right is clipping
-                if (Math.Max(0, component.X) + childSize.W > childViewport.W)
+                if (Math.Max(0, component.X) + childSize.W > Math.Max(childViewport.W, viewportSize.W))
                 {
-                    childSize.W -= (Math.Max(0, component.X) + childSize.W) - childViewport.W;
+                    childSize.W -= (Math.Max(0, component.X) + childSize.W) - Math.Max(childViewport.W, viewportSize.W);
                 }
                 /* HEIGHT CHECKS */
                 // check top is clipping
@@ -266,9 +266,9 @@ namespace Cerulean.Components
                     offsetY = oldY + component.Y;
                 }
                 // check bottom is clipping
-                if (Math.Max(0, component.Y) + childSize.H > childViewport.H)
+                if (Math.Max(0, component.Y) + childSize.H > Math.Max(childViewport.H, viewportSize.H))
                 {
-                    childSize.H -= (Math.Max(0, component.Y) + childSize.H) - childViewport.H;
+                    childSize.H -= (Math.Max(0, component.Y) + childSize.H) - Math.Max(childViewport.H, viewportSize.H);
                 }
 
                 // skip draw if component has invalid area.

--- a/Cerulean.Components/Containers/Panel.cs
+++ b/Cerulean.Components/Containers/Panel.cs
@@ -18,7 +18,7 @@ namespace Cerulean.Components
         public override void Update(object? window, Size clientArea)
         {
             ClientArea = Size ?? clientArea;
-            base.Update(window, clientArea);
+            base.Update(window, ClientArea.Value);
         }
 
         public override void Draw(IGraphics graphics, int viewportX, int viewportY, Size viewportSize)


### PR DESCRIPTION
Fixes child `clientArea` calculation for grid updates.
Fix is just Math.Min on addition of related rows & columns.