### PR TITLE
Adds AutoScale prop to Window and font scaling for components with text.

### DIFF
--- a/Cerulean.Common/Base/Component.cs
+++ b/Cerulean.Common/Base/Component.cs
@@ -10,6 +10,7 @@ namespace Cerulean.Common
     {
         private readonly List<(EventHook, Action<Component, object[]>)> _eventHooks = new();
         private readonly Dictionary<string, Component> _components = new();
+        private object? _parentWindow = null;
         protected Size? CachedViewportSize;
         protected int? CachedViewportX, CachedViewportY;
         protected bool CanBeChild { get; init; } = true;
@@ -27,6 +28,12 @@ namespace Cerulean.Common
         public virtual bool IsHoverableComponent { get; set; } = false;
         public Size? ClientArea { get; protected set; }
         public virtual bool Modified { get; protected set; }
+
+        public object? ParentWindow
+        {
+            get => _parentWindow ?? Parent?.ParentWindow;
+            set => _parentWindow = value;
+        }
 
         public object this[string attribute]
         {

--- a/Cerulean.Common/Interfaces/IGraphics.cs
+++ b/Cerulean.Common/Interfaces/IGraphics.cs
@@ -1,4 +1,6 @@
-﻿namespace Cerulean.Common
+﻿using System.Security.Principal;
+
+namespace Cerulean.Common
 {
     public interface IGraphics
     {
@@ -39,6 +41,12 @@
 
         public (int, int) MeasureText(string text, string fontName, string fontStyle, int fontPointSize,
             int textWrap = 0);
+        #endregion
+
+        #region Utilities
+
+        public float GetCurrentDisplayDpi();
+
         #endregion
 
         #region API FUNCTIONS

--- a/Cerulean.Components/Graphical/Label.cs
+++ b/Cerulean.Components/Graphical/Label.cs
@@ -153,12 +153,14 @@ namespace Cerulean.Components
             if (!ForeColor.HasValue || Text == string.Empty)
                 return;
 
+            var window = ParentWindow as Window;
+
             var size = ClientArea.Value;
             size.W -= X;
             size.H -= Y;
             var textWrap = size.W;
             if (textWrap >= 0)
-                graphics.DrawText(0, 0, Text, FontName, FontStyle, FontSize, ForeColor.Value, WrapText ? (uint)(textWrap) : 0);
+                graphics.DrawText(0, 0, Text, FontName, FontStyle, Scaling.GetDpiScaledValue(window, FontSize), ForeColor.Value, WrapText ? (uint)(textWrap) : 0);
 
             CallHook(this, EventHook.AfterDraw, graphics, viewportX, viewportY, viewportSize);
         }

--- a/Cerulean.Components/Input/Button.cs
+++ b/Cerulean.Components/Input/Button.cs
@@ -180,9 +180,9 @@ namespace Cerulean.Components
 
             base.Update(window, clientArea);
 
-            // process events
             if (window is not Window ceruleanWindow)
                 return;
+
             var hovering = ceruleanWindow.HoveredComponent == this;
 
             // prepare event args
@@ -252,6 +252,8 @@ namespace Cerulean.Components
 
             CallHook(this, EventHook.BeforeDraw, graphics, viewportX, viewportY, viewportSize);
 
+            var window = ParentWindow as Window;
+
             // draw background
             var backgroundColor = BackColor;
             if (_hovered)
@@ -273,11 +275,11 @@ namespace Cerulean.Components
                 FontSize > 0 &&
                 ForeColor.HasValue)
             {
-                var (w, h) = graphics.MeasureText(Text, FontName, FontStyle, FontSize, viewportSize.W);
-                var textX = Math.Max(0, viewportSize.W - w) / 2;
-                var textY = Math.Max(0, viewportSize.H - h) / 2;
+                var (w, h) = graphics.MeasureText(Text, FontName, FontStyle, Scaling.GetDpiScaledValue(window, FontSize), viewportSize.W);
+                var textX = Scaling.GetDpiScaledValue(window, Math.Max(0, viewportSize.W - w) / 2);
+                var textY = Scaling.GetDpiScaledValue(window, Math.Max(0, viewportSize.H - h) / 2);
 
-                graphics.DrawText(textX, textY, Text, FontName, FontStyle, FontSize, ForeColor.Value, (uint)viewportSize.W);
+                graphics.DrawText(textX, textY, Text, FontName, FontStyle, Scaling.GetDpiScaledValue(window, FontSize), ForeColor.Value, (uint)viewportSize.W);
             }
 
             // draw border

--- a/Cerulean.Core/Cerulean.Core.csproj
+++ b/Cerulean.Core/Cerulean.Core.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>

--- a/Cerulean.Core/Cerulean.Core.csproj.DotSettings
+++ b/Cerulean.Core/Cerulean.Core.csproj.DotSettings
@@ -1,3 +1,4 @@
 ﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
 	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=hooks/@EntryIndexedValue">True</s:Boolean>
-	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=reflection/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>
+	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=reflection/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=windowing/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/Cerulean.Core/Implementations/Graphics/SDL2/SDL2Graphics.cs
+++ b/Cerulean.Core/Implementations/Graphics/SDL2/SDL2Graphics.cs
@@ -483,5 +483,16 @@ namespace Cerulean.Core
             return (textWrap, totalRows * h);
         }
         #endregion
+        #region UTILITIES
+
+        public float GetCurrentDisplayDpi()
+        {
+            var displayIndex = SDL_GetWindowDisplayIndex(WindowPtr);
+            if (SDL_GetDisplayDPI(displayIndex, out var ddpi, out _, out _) != 0)
+                return 0;
+            return ddpi;
+        }
+
+        #endregion
     }
 }

--- a/Cerulean.Core/Windowing/Scaling.cs
+++ b/Cerulean.Core/Windowing/Scaling.cs
@@ -1,0 +1,62 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Cerulean.Common;
+
+namespace Cerulean.Core
+{
+    public static class Scaling
+    {
+        public static double GetDpiScaledValue(Window? window, double value)
+        {
+            if (window == null)
+                return value;
+            var dpi = window.GraphicsContext?.GetCurrentDisplayDpi() ?? 96;
+            var scale = window.AutoScale ? dpi / 96f : 1f;
+
+            return value * scale;
+        }
+
+        public static int GetDpiScaledValue(Window? window, int value)
+        {
+            if (window == null)
+                return value;
+            var dpi = window.GraphicsContext?.GetCurrentDisplayDpi() ?? 96;
+            var scale = window.AutoScale ? dpi / 96f : 1f;
+
+            return (int)Math.Floor(value * scale);
+        }
+
+        public static Size GetDpiScaledValue(Window? window, Size value)
+        {
+            if (window == null)
+                return value;
+            return new Size()
+            {
+                W = GetDpiScaledValue(window, value.W),
+                H = GetDpiScaledValue(window, value.H)
+            };
+        }
+
+        public static Size? GetDpiScaledValue(Window? window, Size? value)
+        {
+            if (window == null || value == null)
+                return value;
+            return new Size()
+            {
+                W = GetDpiScaledValue(window, value.Value.W),
+                H = GetDpiScaledValue(window, value.Value.H)
+            };
+        }
+
+        public static (int, int) GetDpiScaledValue(Window? window, (int, int) value)
+        {
+            if (window == null)
+                return value;
+            return (GetDpiScaledValue(window, value.Item1),
+                    GetDpiScaledValue(window, value.Item2));
+        }
+    }
+}

--- a/Cerulean.Core/Windowing/Window.cs
+++ b/Cerulean.Core/Windowing/Window.cs
@@ -90,6 +90,10 @@ namespace Cerulean.Core
         /// </summary>
         public bool AlwaysRedraw { get; set; } = false;
         /// <summary>
+        /// Scales the components of this window via dpi scaling.
+        /// </summary>
+        public bool AutoScale { get; set; } = true;
+        /// <summary>
         /// The graphics context or backend that the window is using.
         /// </summary>
         public IGraphics? GraphicsContext { get; private set; }
@@ -281,6 +285,7 @@ namespace Cerulean.Core
             MinimumWindowSize = null;
             MaximumWindowSize = null;
             Layout = windowLayout;
+            windowLayout.ParentWindow = this;
             ParentWindow = parentWindow;
             _graphicsFactory = graphicsFactory;
             BackColor = new Color(230, 230, 230);
@@ -328,6 +333,31 @@ namespace Cerulean.Core
         public void FlagForRedraw()
         {
             IsFlaggedForRedraw = true;
+        }
+
+        public int GetDpiScaledValue(int value)
+        {
+            return (int)Scaling.GetDpiScaledValue(this, value);
+        }
+
+        public double GetDpiScaledValue(double value)
+        {
+            return Scaling.GetDpiScaledValue(this, value);
+        }
+
+        public float GetDpiScaledValue(float value)
+        {
+            return (float)Scaling.GetDpiScaledValue(this, value);
+        }
+
+        public Size GetDpiScaledValue(Size value)
+        {
+            var ret = new Size
+            {
+                W = GetDpiScaledValue(value.W),
+                H = GetDpiScaledValue(value.H)
+            };
+            return ret;
         }
 
         private void EnsureMainThread(string? message = null)


### PR DESCRIPTION
Adds `AutoScale` property to window which enables Dpi scaling.
Adds `Scaling` static helper class which respects `Window.AutoScale`.
Adds `ParentWindow` to base component which navigates child tree to get parent window.
Adds font scaling to Button and Label component, and by extension, CheckBox.